### PR TITLE
Remove redundant link in README and lib.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Quaternions for Rust.
 
-`num-quaternion` is a Rust library [designed for robust, efficient and easy to
-use](DESIGN_RATIONALE.md) quaternion arithmetic and operations.
+`num-quaternion` is a Rust library designed for robust, efficient and easy to
+use quaternion arithmetic and operations.
 [Quaternions](https://en.wikipedia.org/wiki/Quaternion) are used extensively
 in computer graphics, robotics, and physics for representing rotations and
 orientations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 //! Quaternions for Rust.
 //!
-//! `num-quaternion` is a Rust library [designed for robust, efficient and easy
-//! to use](DESIGN_RATIONALE.md) quaternion arithmetic and operations.
-//! [`Quaternion`]s and [`UnitQuaternion`]s are used extensively in
-//! computer graphics, robotics, and physics for representing rotations and
-//! orientations.
+//! `num-quaternion` is a Rust library designed for robust, efficient and easy
+//! to use quaternion arithmetic and operations. [`Quaternion`]s and
+//! [`UnitQuaternion`]s are used extensively in computer graphics, robotics,
+//! and physics for representing rotations and orientations.
 //!
 //! # Features
 //!


### PR DESCRIPTION
## Summary

The pull request removes a redundant link in the first paragraph of the README.md file and in the top-level documentation of the lib.rs file. The link was considered a distraction for newcomers and can be found further down in the README.md and lib.rs files with a clearer description.

## Related Issue

None

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
