### PR TITLE
Split `impl` blocks.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,13 @@ where
             T::nan()
         }
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float,
+{
     /// Calculates |self| without branching.
     ///
     /// This function returns the same result as [`norm`](Self::norm), if
@@ -562,7 +568,13 @@ where
     pub fn fast_norm(self) -> T {
         self.norm_sqr().sqrt()
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float,
+{
     /// Normalizes the quaternion to length $1$.
     ///
     /// The sign of the real part will be the same as the sign of the input.
@@ -1137,7 +1149,13 @@ where
             }
         }
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float + FloatConst,
+{
     /// Raises a real value (`base`) to a quaternion (`self`) power.
     ///
     /// Given a quaternion $q$ and a real value $t$, this function computes
@@ -1197,7 +1215,13 @@ where
             (self * base.ln()).exp()
         }
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float + FloatConst,
+{
     /// Raises a quaternion (`self`) to a real value (`exponent`) power.
     ///
     /// Given a quaternion $q$ and a real value $t$, this function computes
@@ -1289,7 +1313,13 @@ where
             && self.y.is_finite()
             && self.z.is_finite()
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float + FloatConst,
+{
     /// Computes the natural logarithm of a quaternion.
     ///
     /// The function implements the following guarantees for extreme input
@@ -1438,7 +1468,13 @@ where
             }
         }
     }
+}
 
+#[cfg(any(feature = "std", feature = "libm"))]
+impl<T> Quaternion<T>
+where
+    T: Float + FloatConst,
+{
     // Computes the square root of a quaternion.
     ///
     /// Given the input quaternion $c$, this function returns the quaternion


### PR DESCRIPTION
## Summary

Functions that don't belong together are now separated into different impl blocks. This is a pure refactoring. It improves the aesthetics of the code and the documentation.

## Related Issue

None

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
