### PR TITLE
Provide `into_inner` method for `UnitQuaternion<T>`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2267,9 +2267,24 @@ where
 
 impl<T> UnitQuaternion<T> {
     /// Returns the inner quaternion.
+    ///
+    /// This function does the same as
+    /// [`into_inner`](UnitQuaternion::into_inner). Client code can decide
+    /// which function to use based on the naming preference and context.
     #[inline]
     pub fn into_quaternion(self) -> Quaternion<T> {
         self.0
+    }
+
+    /// Returns the inner quaternion.
+    ///
+    /// This function does the same as
+    /// [`into_quaternion`](UnitQuaternion::into_quaternion). Client code can
+    /// decide which function to use based on the naming preference and
+    /// context.
+    #[inline]
+    pub fn into_inner(self) -> Quaternion<T> {
+        self.into_quaternion()
     }
 
     /// Returns a reference to the inner quaternion.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2833,6 +2833,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use core::borrow::Borrow;
     #[cfg(feature = "std")]
     use core::hash::Hash;
     #[cfg(feature = "std")]
@@ -4840,6 +4841,46 @@ mod tests {
     #[test]
     fn test_unit_quaternion_k_func() {
         assert_eq!(UQ32::k().into_quaternion(), Q32::k());
+    }
+
+    #[test]
+    fn test_into_quaternion() {
+        // Test that the conversion from a unit quaternion to a quaternion
+        // is correct.
+        assert_eq!(UQ32::ONE.into_quaternion(), Q32::ONE);
+        assert_eq!(UQ32::I.into_quaternion(), Q32::I);
+        assert_eq!(UQ32::J.into_quaternion(), Q32::J);
+        assert_eq!(UQ32::K.into_quaternion(), Q32::K);
+    }
+
+    #[test]
+    fn test_into_inner() {
+        // Test that the conversion from a unit quaternion to a quaternion
+        // is correct.
+        assert_eq!(UQ32::ONE.into_inner(), Q32::ONE);
+        assert_eq!(UQ32::I.into_inner(), Q32::I);
+        assert_eq!(UQ32::J.into_inner(), Q32::J);
+        assert_eq!(UQ32::K.into_inner(), Q32::K);
+    }
+
+    #[test]
+    fn test_as_quaternion() {
+        // Test that the conversion from a unit quaternion to a quaternion
+        // is correct.
+        assert_eq!(UQ32::ONE.as_quaternion(), &Q32::ONE);
+        assert_eq!(UQ32::I.as_quaternion(), &Q32::I);
+        assert_eq!(UQ32::J.as_quaternion(), &Q32::J);
+        assert_eq!(UQ32::K.as_quaternion(), &Q32::K);
+    }
+
+    #[test]
+    fn test_borrow() {
+        // Test that the conversion from a unit quaternion to a quaternion
+        // is correct.
+        assert_eq!(<UQ32 as Borrow<Q32>>::borrow(&UQ32::ONE), &Q32::ONE);
+        assert_eq!(<UQ32 as Borrow<Q32>>::borrow(&UQ32::I), &Q32::I);
+        assert_eq!(<UQ32 as Borrow<Q32>>::borrow(&UQ32::J), &Q32::J);
+        assert_eq!(<UQ32 as Borrow<Q32>>::borrow(&UQ32::K), &Q32::K);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This new function provides the same functionality as `into_quaternion`. The name `into_inner` is more idiomatic, yet `into_quaternion` may be more clear in some contexts. That is why both functions are justified.

## Related Issue

None

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
