### PR TITLE
Changed an `assert` to `debug_assert`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1139,7 +1139,9 @@ where
                     )
                 } else {
                     // Angle is super large or NaN
-                    assert!(sqr_angle.is_infinite() || sqr_angle.is_nan());
+                    debug_assert!(
+                        sqr_angle.is_infinite() || sqr_angle.is_nan()
+                    );
                     Self::nan()
                 }
             }


### PR DESCRIPTION
## Summary

Changed an `assert` to `debug_assert`. in regular code apart from tests, the `assert` macro should generally not be used, but the `debug_assert` macro should be used instead. This PR fixes a violation of that rule. 

## Related Issue

None

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
