### PR TITLE
Add test coverage scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Please keep in alphabetical order
 
 Cargo.lock
+*.profdata
+*.profraw
 /target
 /.vscode/
 

--- a/ci/test_coverage_llvm.sh
+++ b/ci/test_coverage_llvm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install cargo tarpaulin if not already installed
+cargo clean
+
+RUSTFLAGS="-C instrument-coverage" rustup run 1.61.0 cargo t
+llvm-profdata merge default.profraw -o num-quaternion.profdata
+
+# Find the newest file matching the pattern
+newest_file=$(find target/debug/deps -name 'num_quaternion-*' -type f | grep -E 'num_quaternion-[0-9a-f]+$' | sort -r | head -n 1)
+
+llvm-cov-14 show -Xdemangler=rustfilt -instr-profile=num-quaternion.profdata --use-color --object "$newest_file" --ignore-filename-regex=/.cargo/registry | less -R

--- a/ci/test_coverage_tarpaulin.sh
+++ b/ci/test_coverage_tarpaulin.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-CRATE=num-quaternion
-MSRV=1.61  # minimum supported rust version
-
 # Install cargo tarpaulin if not already installed
 cargo install cargo-tarpaulin
 

--- a/ci/test_coverage_tarpaulin.sh
+++ b/ci/test_coverage_tarpaulin.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+CRATE=num-quaternion
+MSRV=1.61  # minimum supported rust version
+
+# Install cargo tarpaulin if not already installed
+cargo install cargo-tarpaulin
+
+# Generate test coverage data
+cargo tarpaulin --engine Llvm --fail-under 80 --all-features


### PR DESCRIPTION
## Summary

This pull request adds scripts for test coverage using `cargo-tarpaulin` and `llvm-cov-14`. The `.gitignore` file is also updated to include profiling file patterns. These scripts allow for generating test coverage data and displaying it in a readable format.

## Related Issue

Fixes #18

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
