### PR TITLE
Add documentation and test cases for UnitQuaternion::from_rotation_vector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1876,6 +1876,10 @@ where
     ///
     /// This function is the inverse of
     /// [`to_rotation_vector`](UnitQuaternion::to_rotation_vector).
+    ///
+    /// The results of this function may not be accurate, if the input has a
+    /// very large norm. If the input vector is not finite (i. e. it contains
+    /// an infinite or `NaN` component), then the result is filled with `NaN`.
     pub fn from_rotation_vector(v: &[T; 3]) -> Self {
         let sqr_norm = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
         let two = T::one() + T::one();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4814,6 +4814,32 @@ mod tests {
 
     #[cfg(any(feature = "std", feature = "libm"))]
     #[test]
+    fn test_from_rotation_vector_infinite() {
+        // Test `from_rotation_vector` for a vector with infinite components.
+        let inf = f32::INFINITY;
+        assert!(UQ32::from_rotation_vector(&[inf, 0.0, 0.0])
+            .into_inner()
+            .is_all_nan());
+        assert!(UQ32::from_rotation_vector(&[inf, inf, inf])
+            .into_inner()
+            .is_all_nan());
+    }
+
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[test]
+    fn test_from_rotation_vector_nan_input() {
+        // Test `from_rotation_vector` for a vector with infinite components.
+        let nan = f32::NAN;
+        assert!(UQ32::from_rotation_vector(&[nan, 0.0, 0.0])
+            .into_inner()
+            .is_all_nan());
+        assert!(UQ32::from_rotation_vector(&[nan, nan, nan])
+            .into_inner()
+            .is_all_nan());
+    }
+
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[test]
     fn test_to_rotation_vector_zero_rotation() {
         // Quaternion representing no rotation (identity quaternion)
         assert_eq!(UQ32::ONE.to_rotation_vector(), [0.0, 0.0, 0.0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4829,11 +4829,11 @@ mod tests {
     #[test]
     fn test_from_rotation_vector_nan_input() {
         // Test `from_rotation_vector` for a vector with infinite components.
-        let nan = f32::NAN;
-        assert!(UQ32::from_rotation_vector(&[nan, 0.0, 0.0])
+        let nan = f64::NAN;
+        assert!(UQ64::from_rotation_vector(&[nan, 0.0, 0.0])
             .into_inner()
             .is_all_nan());
-        assert!(UQ32::from_rotation_vector(&[nan, nan, nan])
+        assert!(UQ64::from_rotation_vector(&[nan, nan, nan])
             .into_inner()
             .is_all_nan());
     }


### PR DESCRIPTION
## Summary

This pull request adds documentation and test cases for the `UnitQuaternion::from_rotation_vector` function. The documentation now mentions that the function may not be accurate for input vectors with a very large norm, and that if the input vector contains an infinite or `NaN` component, the result will be filled with `NaN`. The test cases cover scenarios with infinite and `NaN` inputs, ensuring the expected behavior of the function.

The results for infinite and `NaN` inputs are checked.

## Related Issue

None. 

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
