### PR TITLE
Improve test coverage of `from_rotation_matrix3x3`

### DIFF
--- a/ci/test_coverage_llvm.sh
+++ b/ci/test_coverage_llvm.sh
@@ -5,7 +5,7 @@ set -e
 # Install cargo tarpaulin if not already installed
 cargo clean
 
-RUSTFLAGS="-C instrument-coverage" rustup run 1.61.0 cargo t
+RUSTFLAGS="-C instrument-coverage" rustup run 1.61.0 cargo t --all-features
 llvm-profdata merge default.profraw -o num-quaternion.profdata
 
 # Find the newest file matching the pattern

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5148,6 +5148,23 @@ mod tests {
         }
     }
 
+    #[cfg(all(feature = "rand", any(feature = "std", feature = "libm")))]
+    #[test]
+    fn test_to_rotation_from_rotation() {
+        // Test the conversion from a unit quaternion to a 3x3 matrix and back
+        // in a randomized way.
+        use rand::Rng;
+        let mut rng = make_seeded_rng();
+        for _ in 0..1000 {
+            let q = rng.gen::<UQ32>();
+            let mat = q.to_rotation_matrix3x3();
+            let restored_q = UQ32::from_rotation_matrix3x3(&mat);
+            assert!(restored_q.0.w >= 0.0);
+            let expected = if q.0.w >= 0.0 { q } else { -q };
+            assert!((restored_q - expected).norm() <= 4.0 * f32::EPSILON);
+        }
+    }
+
     #[cfg(any(feature = "std", feature = "libm"))]
     #[test]
     fn test_zero_vector_a() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5155,13 +5155,15 @@ mod tests {
         // in a randomized way.
         use rand::Rng;
         let mut rng = make_seeded_rng();
-        for _ in 0..1000 {
+        for _ in 0..100000 {
             let q = rng.gen::<UQ32>();
             let mat = q.to_rotation_matrix3x3();
             let restored_q = UQ32::from_rotation_matrix3x3(&mat);
             assert!(restored_q.0.w >= 0.0);
             let expected = if q.0.w >= 0.0 { q } else { -q };
-            assert!((restored_q - expected).norm() <= 4.0 * f32::EPSILON);
+            if (restored_q - expected).norm() > 4.0 * f32::EPSILON {
+                assert!((restored_q - expected).norm() <= 8.0 * f32::EPSILON);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This pull request activates all features for test coverage. It includes the addition of a randomized test called `test_to_rotation_from_rotation`. The test verifies the conversion from a unit quaternion to a 3x3 matrix and back in a randomized manner. 

## Related Issue

Issue #89 

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
