### PR TITLE
Add test cases for UnitQuaternion::from_two_vectors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5190,7 +5190,7 @@ mod tests {
         assert_eq!(q.as_quaternion().w, 0.0);
     }
 
-    #[cfg(any(feature = "std", feature = "libm"))]
+    #[cfg(all(feature = "rand", any(feature = "std", feature = "libm")))]
     #[test]
     fn test_opposite_vectors_randomized() {
         // Test `from_two_vectors` for the case where the vectors are opposite


### PR DESCRIPTION
## Summary

This pull request adds new test cases for 100% coverage of the `UnitQuaternion::from_two_vectors` function. The test cases cover scenarios where the vectors are opposite and perpendicular, as well as randomized cases. The goal is to ensure that the function behaves correctly in all scenarios.

## Related Issue

Issue #89

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
