### PR TITLE
Fixed test which tested the wrong function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5415,7 +5415,7 @@ mod tests {
     fn test_unit_quaternion_inv_func() {
         // Test the inverse of unit quaternions
         assert_eq!(
-            Q32::new(1.0, 2.0, 3.0, 4.0).normalize().unwrap().inv(),
+            UQ32::inv(&Q32::new(1.0, 2.0, 3.0, 4.0).normalize().unwrap()),
             Q32::new(1.0, 2.0, 3.0, 4.0).normalize().unwrap().conj()
         )
     }


### PR DESCRIPTION
## Summary

Test coverage showed that the test `test_unit_quaternion_inv_func` tested the `Inv` trait, but not the `inv()` method of `UnitQuaernion`.

## Related Issue

Issue #89

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
