### PR TITLE
Added test for the function `Quaternion::normalize` with subnomal norm.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3329,6 +3329,18 @@ mod tests {
         );
     }
 
+    #[cfg(any(feature = "std", feature = "libm"))]
+    #[test]
+    fn test_normalize_subnormal() {
+        // Test the normalize function for subnormal quaternions
+        let s = f64::MIN_POSITIVE / 4.0;
+        let q = Q64::new(s, s, s, s);
+        assert_eq!(
+            q.normalize().unwrap().into_inner(),
+            Q64::new(0.5, 0.5, 0.5, 0.5)
+        );
+    }
+
     #[test]
     fn test_from_underlying_type_val() {
         // Test the From trait for values


### PR DESCRIPTION
## Summary

Added test for the function `Quaternion::normalize` with subnomal norm.

I tried to improve test coverage as measured by `tarpaulin`. Unfortunately, the coverage did not improve, but the test is still useful. It looks like the coverage is not accurately measured by `tarpaulin`, unfortunately. Manually checking the output of `ci/test_coverage_llvm.sh` shows that lines of executable code in `lib.rs` are fully covered by tests. 

## Related Issue

Issue #89

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
