### PR TITLE
Update Quaternion documentation with interop details

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ orientations.
   and more.
 - **Interpolation**: Spherical linear interpolation (SLERP) for smooth
   rotations.
+- **Interoperability**: Works with the `serde` and the `rand` crates.
 - **Comprehensive Documentation**: Detailed documentation with examples to
   help you get started quickly.
 
@@ -50,6 +51,10 @@ Then, include it in your crate:
 ```rust
 use num_quaternion::{Quaternion, UnitQuaternion, Q32, Q64, UQ32, UQ64};
 ```
+
+To serialize or deserialize `Quaternion`s with `serde`, or to randomly sample
+`UnitQuaternion`s using the `rand` crate, enable the respective `serde` or
+`rand` feature.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //!   and more.
 //! - **Interpolation**: Spherical linear interpolation (SLERP) for smooth
 //!   rotations.
+//! - **Interoperability**: Works with the `serde` and the `rand` crates.
 //! - **Comprehensive Documentation**: Detailed documentation with examples to
 //!   help you get started quickly.
 //!
@@ -128,6 +129,11 @@
 //!   data structures where possible. Useful for easy integration with
 //!   serialization frameworks, enabling data storage and communication
 //!   functionalities.
+//!
+//! - `rand`: Implements the `Distribution` trait for `UnitQuaternion`. This
+//!   feature allows you to randomly sample unit quaternions using the `rand`
+//!   crate.
+//!
 //!
 //! # Design Rationale and Error Handling
 //!

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -38,11 +38,22 @@ use {
 ///
 /// `Quaternion`s support the usual arithmetic operations of addition,
 /// subtraction, multiplication, and division. You can compute the
-/// norm with [`norm`](Quaternion::norm) and its square with
-/// [`norm_sqr`](Quaternion::norm_sqr). Quaternion conjugation is done by the
-/// member function [`conj`](Quaternion::conj). You can normalize a
-/// quaternion by calling [`normalize`](Quaternion::normalize), which returns
-/// a [`UnitQuaternion`].
+/// norm with [`norm`](Quaternion::norm) or [`fast_norm`](Quaternion::fast_norm)
+/// and its square with [`norm_sqr`](Quaternion::norm_sqr). Quaternion
+/// conjugation is done by the member function [`conj`](Quaternion::conj).
+/// You can normalize a quaternion by calling
+/// [`normalize`](Quaternion::normalize), which returns a [`UnitQuaternion`].
+///
+/// Furthermore, the following functions are supported:
+///
+/// - [`dot`](Quaternion::dot): Computes the dot product of two quaternions.
+/// - [`exp`](Quaternion::exp): Computes the exponential of a quaternion.
+/// - [`expf`](Quaternion::expf): Raises a real value to a quaternion power.
+/// - [`inv`](Quaternion::inv): Computes the multiplicative inverse.
+/// - [`ln`](Quaternion::ln): Computes the natural logarithm of a quaternion.
+/// - [`powf`](Quaternion::powf): Raises a quaternion to a real power.
+/// - [`powi`](Quaternion::powi): Raises a quaternion to a signed integer power.
+/// - [`powu`](Quaternion::powu): Raises a quaternion to an unsigned integer power.
 ///
 /// To work with rotations, please use [`UnitQuaternion`]s.
 ///

--- a/src/unit_quaternion.rs
+++ b/src/unit_quaternion.rs
@@ -26,12 +26,14 @@ use {
 /// $1$ and $q$ interpreted as 4D vectors.
 ///
 /// You can create a `UnitQuaternion` by normalizing a `Quaternion` using the
-/// [`Quaternion::normalize`](Quaternion::normalize) method. Alternatively, you can use
-/// [`from_euler_angles`](UnitQuaternion::from_euler_angles) or
-/// [`from_rotation_vector`](UnitQuaternion::from_rotation_vector) to obtain
-/// one. The inverse functions
-/// [`to_euler_angles`](UnitQuaternion::to_euler_angles) and
-/// [`to_rotation_vector`](UnitQuaternion::to_rotation_vector) are also
+/// [`Quaternion::normalize`](Quaternion::normalize) method. Alternatively, you
+/// can use [`from_euler_angles`](UnitQuaternion::from_euler_angles),
+/// [`from_rotation_vector`](UnitQuaternion::from_rotation_vector), or
+/// [`from_rotation_matrix3x3`](UnitQuaternion::from_rotation_matrix3x3) to
+/// obtain one. The inverse functions
+/// [`to_euler_angles`](UnitQuaternion::to_euler_angles),
+/// [`to_rotation_vector`](UnitQuaternion::to_rotation_vector), and
+/// [`to_rotation_matrix3x3`](UnitQuaternion::to_rotation_matrix3x3) are also
 /// provided.
 ///
 /// [`UnitQuaternion`] offers the same arithmetic operations as [`Quaternion`].


### PR DESCRIPTION
## Summary

This pull request updates the documentation for the `Quaternion` struct. It adds information about the interop with the `serde` and `rand` crates, including how to serialize or deserialize `Quaternion`s with `serde` and how to randomly sample `UnitQuaternion`s using the `rand` crate. Additionally, it mentiones in the top-level docs the new functions of the `Quaternion` struct, such as `fast_norm` and transcendental functions. The documentation also mentions methods for conversion between `UnitQuaternion` and 3x3 matrices.

## Related Issue

Fixed #106 

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
