### PR TITLE
Add detailed explanation of slerp and euler angles in pose_animation example

### DIFF
--- a/examples/pose_animation.rs
+++ b/examples/pose_animation.rs
@@ -1,8 +1,11 @@
-//! This example program computes intermediate values between two poses.
-//! It clearly demonstrates that spherical linear interpolation (slerp) is
-//! different from linear interpolation of individual euler angles.
-//!
-//!
+//! This example program computes intermediate values between two poses. It
+//! clearly demonstrates that spherical linear interpolation (slerp) is
+//! different from linear interpolation of individual euler angles. Slerp
+//! takes the shortest path between two orientations, while linear interpolation
+//! of euler angles can exhibit gimbal lock and other artifacts. If you're
+//! interested in some details, go watch [Quaternions and 3d rotation, explained
+//! interactively from 3Blue1Brown](https://www.youtube.com/watch?v=zjMuIxRvygQ)
+//! and explore some of the links given in the video description.
 
 use num_quaternion::UQ32;
 


### PR DESCRIPTION
## Summary

This pull request adds a detailed explanation of spherical linear interpolation (slerp) and linear interpolation of individual euler angles in the pose_animation example. The explanation highlights the differences between the two methods and the potential artifacts that can occur with euler angle interpolation. It also includes a link to a 3Blue1Brown video that provides further insights into quaternions and 3D rotation.

## Related Issue

Fixes #106

## Checklist

- [x] Changes are self-reviewed
- [x] Added/updated documentation
- [x] Added tests, if appropriate
