### PR TITLE
Stop num-integer dependency pulling in std by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ default-features = false
 
 [dependencies.num-integer]
 version = "0.1.46"
+default-features = false
 
 [dependencies.serde]
 optional = true


### PR DESCRIPTION
## Summary

The `num-integer` crate, a dependency of `num-quaternion`, by default sets the `std` feature on `num-traits`, which causes `std` to be incorporated into the build... which isn't good if one is trying to use `num-quaternion` in a `#[no_std]` environment. This pull request stops that from happening.

## Related Issue

N/A

## Checklist

- [X] Changes are self-reviewed
- [ ] Added/updated documentation (N/A, I think)
- [ ] Added tests, if appropriate (should there be any?)
