### PR TITLE
Fix deprecated use of `criterion::black_box`. 

### DIFF
--- a/.github/workflows/cargo_build_and_test.yml
+++ b/.github/workflows/cargo_build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust: [
-          1.63.0, # Minimum version determined by cargo-msrv
+          1.66.0, # Minimum version determined by cargo-msrv
           stable,
         ]
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "1.0.4"
 readme = "README.md"
 exclude = ["/.github/*"]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.66.0"
 
 [package.metadata.docs.rs]
 features = ["std", "libm", "serde", "unstable"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,8 @@
 ## [Unreleased]
 
 - Updated versions of dependencies in C++ benchmarks.
+- Updated `criterion` to version `0.7`.
+- Updated minimum supported Rust version to 1.66.0.
 
 ## Release 1.0.4 (2025-04-23)
 

--- a/benches/norm_runtime.rs
+++ b/benches/norm_runtime.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use num_quaternion::{Q32, Q64};
+use std::hint::black_box;
 
 pub fn bench_norm(c: &mut Criterion) {
     {

--- a/ci/rustup.sh
+++ b/ci/rustup.sh
@@ -18,7 +18,7 @@ rustup component add rustfmt
 cargo fmt --check
 
 ci=$(dirname $0)
-rustup update "1.63.0"
-rustup run "1.63.0" "$ci/test_full.sh"
+rustup update "1.66.0"
+rustup run "1.66.0" "$ci/test_full.sh"
 rustup update "stable"
 rustup run "stable" "$ci/test_full.sh --run_tests"

--- a/ci/test_coverage_llvm.sh
+++ b/ci/test_coverage_llvm.sh
@@ -23,7 +23,7 @@ set -e
 cargo clean
 
 # Run the tests with coverage instrumentation
-RUSTFLAGS="-C instrument-coverage" rustup run 1.63.0 cargo t --all-features
+RUSTFLAGS="-C instrument-coverage" rustup run 1.66.0 cargo t --all-features
 
 # Merge the coverage data
 llvm-profdata-14 merge default.profraw -o num-quaternion.profdata


### PR DESCRIPTION
# Summary

## Description of Changes

`criterion::black_box` is deprecated in the latest version of the `criterion` crate. It hints that `std::hint::black_box` should be used instead, which we do in this PR. This in turn requires the Rust version 1.66.0 where the feature was stabilized. Thus I updated the minimum supported Rust version to 1.66.0. 

## Related Issue

None. 

## Checklist

- [x] I have reviewed my changes
- [x] I updated the release notes
- [x] I documented all new code
- [x] I tested all new code

(If an item is not applicable, please check it anyway.)
