### PR TITLE
Implement polynomial approximations and benchmarks for rotation vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ harness = false
 
 [[bench]]
 name = "from_rotation_vector_runtime"
+required-features = ["std", "rand"]
 harness = false
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ rustdoc-args = ["--html-in-header", "katex.html"]
 name = "norm_runtime"
 harness = false
 
+[[bench]]
+name = "from_rotation_vector_runtime"
+harness = false
+
 [[example]]
 name = "benchmark_norm_accuracy"
 required-features = ["std", "rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ required-features = ["std", "rand"]
 name = "pose_animation"
 required-features = ["std"]
 
+[[example]]
+name = "chebyshev_approximation"
+required-features = ["std"]
+
 [dependencies.num-traits]
 version = "0.2"
 default-features = false

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,11 @@
 
 ## [Unreleased]
 
+- Optimized `UnitQuaternion::from_rotation_vector` for small vectors of length
+  less than pi. Speedups of 3x are observed.
+- Added benchmarks for `UnitQuaternion::from_rotation_vector`.
+- Updated `nalgebra` dependency to version `0.34`.
+
 ## Release 1.0.5 (2025-07-27)
 
 - Updated versions of dependencies in C++ benchmarks.

--- a/benches/c++/.bazelrc
+++ b/benches/c++/.bazelrc
@@ -1,2 +1,3 @@
 build --cxxopt='-std=c++20'
 build --cxxopt='-O3'
+build --cxxopt='-fdiagnostics-color=always'

--- a/benches/c++/BUILD.bazel
+++ b/benches/c++/BUILD.bazel
@@ -1,6 +1,16 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 cc_binary(
+    name = "from_rotation_vector_runtime",
+    srcs = ["from_rotation_vector_runtime.cpp"],
+    deps = [
+        "@boost.qvm//:boost.qvm",
+        "@eigen//:eigen",
+        "@google_benchmark//:benchmark",
+    ],
+)
+
+cc_binary(
     name = "norm_accuracy",
     srcs = ["norm_accuracy.cpp"],
     deps = [

--- a/benches/c++/from_rotation_vector_runtime.cpp
+++ b/benches/c++/from_rotation_vector_runtime.cpp
@@ -1,0 +1,134 @@
+#include <benchmark/benchmark.h>
+
+#include <boost/qvm/quat.hpp>
+#include <boost/qvm/quat_operations.hpp>
+#include <boost/qvm/vec.hpp>
+
+#include <Eigen/Geometry>
+
+#include <cmath>
+#include <random>
+#include <ranges>
+#include <vector>
+
+// Generates random Rodriguez vectors with norm < PI
+std::vector<std::array<float, 3>> generate_random_vectors(size_t count) {
+  std::mt19937 rng(0x7F0829AE4D31C6B5);
+  std::uniform_real_distribution<float> dist(-M_PI, M_PI);
+
+  std::vector<std::array<float, 3>> vectors;
+  vectors.reserve(count);
+
+  for (size_t i = 0; i < count; ++i) {
+    while (true) {
+      std::array<float, 3> v{dist(rng), dist(rng), dist(rng)};
+      float norm_squared = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
+      if (norm_squared < M_PI * M_PI) {
+        vectors.push_back(v);
+        break;
+      }
+    }
+  }
+
+  return vectors;
+}
+
+// Computes the norms of the given vectors and returns them in an array.
+std::vector<float>
+compute_norms(const std::vector<std::array<float, 3>> &vectors) {
+  std::vector<float> norms;
+  norms.reserve(vectors.size());
+  for (const auto &v : vectors) {
+    float norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    norms.push_back(norm);
+  }
+  return norms;
+}
+
+// Computes the normalized vectors from the given vectors
+std::vector<std::array<float, 3>>
+compute_normalized_vectors(std::vector<std::array<float, 3>> vectors) {
+
+  for (auto &v : vectors) {
+    float norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    if (norm != 0) {
+      v[0] /= norm;
+      v[1] /= norm;
+      v[2] /= norm;
+    }
+  }
+  return std::move(vectors);
+}
+
+// Benchmark for computing a quaternion from an axis vector and an angle
+// using Boost QVM
+static void BM_QuaternionFromRotationVectorBoostQVM(benchmark::State &state) {
+  const auto inputs = generate_random_vectors(2000);
+  const auto angles = compute_norms(inputs);
+  for (auto _ : state) {
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      const auto &axis = inputs[i];
+      float angle = angles[i];
+      boost::qvm::vec<float, 3> axis_c = {axis[0], axis[1], axis[2]};
+      boost::qvm::quat<float> q;
+      boost::qvm::set_rot(q, axis_c, angle);
+      benchmark::DoNotOptimize(q);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * inputs.size());
+}
+
+BENCHMARK(BM_QuaternionFromRotationVectorBoostQVM);
+
+// Benchmark for computing a quaternion from an axis vector and an angle
+// using Eigen
+static void BM_QuaternionFromRotationVectorEigen(benchmark::State &state) {
+  auto inputs = generate_random_vectors(2000);
+  const auto angles = compute_norms(inputs);
+  inputs = compute_normalized_vectors(std::move(inputs));
+  for (auto _ : state) {
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      const auto &v = inputs[i];
+      float angle = angles[i];
+      auto q = Eigen::Quaternionf{
+          Eigen::AngleAxisf{angle, Eigen::Vector3f(v[0], v[1], v[2])}};
+      benchmark::DoNotOptimize(q);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * inputs.size());
+}
+
+BENCHMARK(BM_QuaternionFromRotationVectorEigen);
+
+template <typename T> class Quaternion {
+public:
+  Quaternion(T w, T x, T y, T z) : w(w), x(x), y(y), z(z) {}
+
+  static Quaternion from_rotation_vector(const std::array<T, 3> &v) {
+    T norm = std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    T half_angle = norm / 2;
+    T sin_half_angle = std::sin(half_angle);
+    T imag_factor = sin_half_angle / norm;
+    return Quaternion(std::cos(half_angle), imag_factor * v[0],
+                      imag_factor * v[1], imag_factor * v[2]);
+  }
+
+  T w, x, y, z;
+};
+
+// Benchmark for computing a quaternion from a vector (direction = axis,
+// norm = angle) using a manual implementation
+static void BM_QuaternionFromRotationVectorManualImpl(benchmark::State &state) {
+  auto inputs = generate_random_vectors(2000);
+  for (auto _ : state) {
+    for (const auto &v : inputs) {
+      Quaternion<float> q = Quaternion<float>::from_rotation_vector(v);
+      benchmark::DoNotOptimize(q);
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * inputs.size());
+}
+
+BENCHMARK(BM_QuaternionFromRotationVectorManualImpl);
+
+BENCHMARK_MAIN();

--- a/benches/from_rotation_vector_runtime.rs
+++ b/benches/from_rotation_vector_runtime.rs
@@ -48,13 +48,9 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
             b.iter(|| {
                 // The code inside this closure is what's measured.
                 for i in 0..BATCH_SIZE {
-                    // Use `black_box` on the input to prevent the compiler from
-                    // making assumptions.
                     let input_vec = black_box(&inputs[i]);
                     outputs[i] = UQ32::from_rotation_vector(input_vec);
                 }
-                // Use `black_box` on the output to ensure the write to the
-                // vector is not optimized away.
                 black_box(&mut outputs);
             })
         });
@@ -64,8 +60,6 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
                 b.iter(|| {
                     // The code inside this closure is what's measured.
                     for i in 0..BATCH_SIZE {
-                        // Use `black_box` on the input to prevent the compiler
-                        // from making assumptions.
                         let input_vec = black_box(&inputs[i]);
                         let sqr_norm = input_vec[0] * input_vec[0]
                             + input_vec[1] * input_vec[1]
@@ -74,8 +68,6 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
                             input_vec, sqr_norm,
                         );
                     }
-                    // Use `black_box` on the output to ensure the write to the
-                    // vector is not optimized away.
                     black_box(&mut outputs);
                 })
             },
@@ -86,8 +78,6 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
                 b.iter(|| {
                     // The code inside this closure is what's measured.
                     for i in 0..BATCH_SIZE {
-                        // Use `black_box` on the input to prevent the compiler
-                        // from making assumptions.
                         let input_vec = black_box(&inputs[i]);
                         let sqr_norm = input_vec[0] * input_vec[0]
                             + input_vec[1] * input_vec[1]
@@ -96,8 +86,6 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
                             input_vec, sqr_norm,
                         );
                     }
-                    // Use `black_box` on the output to ensure the write to the
-                    // vector is not optimized away.
                     black_box(&mut outputs);
                 })
             },

--- a/benches/from_rotation_vector_runtime.rs
+++ b/benches/from_rotation_vector_runtime.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use num_quaternion::{UQ32, UQ64};
+use num_quaternion::UQ32;
 use rand::Rng;
 use rand::SeedableRng;
 use std::f32::consts::PI;
@@ -28,13 +28,15 @@ fn generate_random_vectors(count: usize) -> Vec<[f32; 3]> {
 
 pub fn bench_from_rotation_vector(c: &mut Criterion) {
     {
-        // We'll process a batch of vectors in each iteration to measure throughput accurately.
+        // We'll process a batch of vectors in each iteration to measure
+        // throughput accurately.
         const BATCH_SIZE: usize = 2_000;
 
         // Pre-generate the random input data.
         let inputs = generate_random_vectors(BATCH_SIZE);
 
-        // Create a buffer for the results to ensure the compiler can't optimize away the work.
+        // Create a buffer for the results to ensure the compiler can't optimize
+        // away the work.
         let mut outputs = vec![UQ32::default(); BATCH_SIZE];
 
         let mut group = c.benchmark_group("batch_conversion");
@@ -42,26 +44,28 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
         // Set the measurement to be based on the number of elements processed.
         group.throughput(Throughput::Elements(BATCH_SIZE as u64));
 
-        // Define the benchmark. `b.iter` runs the provided closure multiple times.
         group.bench_function("UQ32::from_rotation_vector", |b| {
             b.iter(|| {
                 // The code inside this closure is what's measured.
                 for i in 0..BATCH_SIZE {
-                    // Use `black_box` on the input to prevent the compiler from making assumptions.
+                    // Use `black_box` on the input to prevent the compiler from
+                    // making assumptions.
                     let input_vec = black_box(&inputs[i]);
                     outputs[i] = UQ32::from_rotation_vector(input_vec);
                 }
-                // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                // Use `black_box` on the output to ensure the write to the
+                // vector is not optimized away.
                 black_box(&mut outputs);
             })
         });
         group.bench_function(
-            "UQ32::from_rotation_vector_f32_polynomial",
+            "UQ32::from_rotation_vector_f32_polynomial (internal implementation)",
             |b| {
                 b.iter(|| {
                     // The code inside this closure is what's measured.
                     for i in 0..BATCH_SIZE {
-                        // Use `black_box` on the input to prevent the compiler from making assumptions.
+                        // Use `black_box` on the input to prevent the compiler
+                        // from making assumptions.
                         let input_vec = black_box(&inputs[i]);
                         let sqr_norm = input_vec[0] * input_vec[0]
                             + input_vec[1] * input_vec[1]
@@ -70,24 +74,115 @@ pub fn bench_from_rotation_vector(c: &mut Criterion) {
                             input_vec, sqr_norm,
                         );
                     }
-                    // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                    // Use `black_box` on the output to ensure the write to the
+                    // vector is not optimized away.
                     black_box(&mut outputs);
                 })
             },
         );
-        group.bench_function("UQ32::from_rotation_vector_generic", |b| {
+        group.bench_function(
+            "UQ32::from_rotation_vector_generic (internal implementation)",
+            |b| {
+                b.iter(|| {
+                    // The code inside this closure is what's measured.
+                    for i in 0..BATCH_SIZE {
+                        // Use `black_box` on the input to prevent the compiler
+                        // from making assumptions.
+                        let input_vec = black_box(&inputs[i]);
+                        let sqr_norm = input_vec[0] * input_vec[0]
+                            + input_vec[1] * input_vec[1]
+                            + input_vec[2] * input_vec[2];
+                        outputs[i] = UQ32::from_rotation_vector_generic(
+                            input_vec, sqr_norm,
+                        );
+                    }
+                    // Use `black_box` on the output to ensure the write to the
+                    // vector is not optimized away.
+                    black_box(&mut outputs);
+                })
+            },
+        );
+
+        let axis_angles = inputs
+            .iter()
+            .map(|v| {
+                let norm = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+                if norm != 0.0 {
+                    [v[0] / norm, v[1] / norm, v[2] / norm, norm]
+                } else {
+                    [1.0, 0.0, 0.0, 0.0]
+                }
+            })
+            .collect::<Vec<_>>();
+        let mut outputs = vec![Default::default(); BATCH_SIZE];
+        group.bench_function("quaternion::axis_angle", |b| {
             b.iter(|| {
                 // The code inside this closure is what's measured.
                 for i in 0..BATCH_SIZE {
-                    // Use `black_box` on the input to prevent the compiler from making assumptions.
-                    let input_vec = black_box(&inputs[i]);
-                    let sqr_norm = input_vec[0] * input_vec[0]
-                        + input_vec[1] * input_vec[1]
-                        + input_vec[2] * input_vec[2];
-                    outputs[i] =
-                        UQ32::from_rotation_vector_generic(input_vec, sqr_norm);
+                    // The interfaces of the `quaternion` crate expects a vector
+                    // of unit length for the axis and a scalar for the angle.
+                    // To make the comparison fair, we compute these values
+                    // before the benchmark starts and feed them in here.
+                    let input_vec = black_box(&axis_angles[i]);
+                    outputs[i] = quaternion::axis_angle(
+                        [input_vec[0], input_vec[1], input_vec[2]],
+                        input_vec[3],
+                    );
                 }
-                // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                black_box(&mut outputs);
+            })
+        });
+
+        let mut outputs = vec![Default::default(); BATCH_SIZE];
+        group.bench_function("quaternion_core::from_rotation_vector", |b| {
+            b.iter(|| {
+                // The code inside this closure is what's measured.
+                for i in 0..BATCH_SIZE {
+                    let input_vec = black_box(inputs[i]);
+                    outputs[i] =
+                        quaternion_core::from_rotation_vector(input_vec);
+                }
+                black_box(&mut outputs);
+            })
+        });
+
+        let mut outputs = vec![Default::default(); BATCH_SIZE];
+        group.bench_function("nalgebra::geometry::Quaternion::from_polar_decomposition", |b| {
+            b.iter(|| {
+                // The code inside this closure is what's measured.
+                for i in 0..BATCH_SIZE {
+                    let input_vec = black_box(axis_angles[i]);
+                    // The interfaces of the `nalgebra` crate expects a vector
+                    // of unit length for the axis, a scalar for the angle and
+                    // a scalar for the norm. To make the comparison fair, we
+                    // compute these values before the benchmark starts and feed
+                    // them in here.
+                    outputs[i] = nalgebra::geometry::Quaternion::from_polar_decomposition(
+                        1.0, input_vec[3], nalgebra::Unit::new_unchecked(
+                            nalgebra::Vector3::new(input_vec[0], input_vec[1], input_vec[2])),
+                    );
+                }
+                black_box(&mut outputs);
+            })
+        });
+
+        let mut outputs = vec![Default::default(); BATCH_SIZE];
+        group.bench_function("micromath::Quaternion::axis_angle", |b| {
+            b.iter(|| {
+                // The code inside this closure is what's measured.
+                for i in 0..BATCH_SIZE {
+                    let input_vec = black_box(axis_angles[i]);
+                    // Similarly to the `quaternion` crate we precompute the
+                    // axis and angle values to make the comparison fair.
+                    outputs[i] = micromath::Quaternion::axis_angle(
+                        micromath::vector::Vector3d {
+                            x: input_vec[0],
+                            y: input_vec[1],
+                            z: input_vec[2],
+                        },
+                        input_vec[3],
+                    );
+                }
                 black_box(&mut outputs);
             })
         });

--- a/benches/from_rotation_vector_runtime.rs
+++ b/benches/from_rotation_vector_runtime.rs
@@ -1,0 +1,67 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use num_quaternion::{UQ32, UQ64};
+use std::hint::black_box;
+
+pub fn bench_from_rotation_vector(c: &mut Criterion) {
+    {
+        let mut group = c.benchmark_group("num_quaternion");
+        group.bench_function("UQ32::from_rotation_vector", |b| {
+            b.iter(|| black_box(UQ32::from_rotation_vector(&[1.0, 2.0, 0.5])))
+        });
+        group.bench_function("UQ64::from_rotation_vector", |b| {
+            b.iter(|| black_box(UQ64::from_rotation_vector(&[1.0, 2.0, 0.5])))
+        });
+    }
+    {
+        let mut group = c.benchmark_group("f32 polynomial");
+        group.bench_function(
+            "UQ32::from_rotation_vector_f32_polynomial",
+            |b| {
+                b.iter(|| {
+                    black_box(UQ32::from_rotation_vector_f32_polynomial(
+                        &[1.0, 2.0, 0.5],
+                        5.25,
+                    ))
+                })
+            },
+        );
+        group.bench_function(
+            "UQ64::from_rotation_vector_f32_polynomial",
+            |b| {
+                b.iter(|| {
+                    black_box(UQ64::from_rotation_vector_f32_polynomial(
+                        &[1.0, 2.0, 0.5],
+                        5.25,
+                    ))
+                })
+            },
+        );
+    }
+    {
+        let mut group = c.benchmark_group("generic implementation");
+        group.bench_function("UQ32::from_rotation_vector_generic", |b| {
+            b.iter(|| {
+                black_box(UQ32::from_rotation_vector_generic(
+                    &[1.0, 2.0, 0.5],
+                    5.25,
+                ))
+            })
+        });
+        group.bench_function("UQ64::from_rotation_vector_generic", |b| {
+            b.iter(|| {
+                black_box(UQ64::from_rotation_vector_generic(
+                    &[1.0, 2.0, 0.5],
+                    5.25,
+                ))
+            });
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().significance_level(0.01).sample_size(2000);
+    targets = bench_from_rotation_vector
+}
+
+criterion_main!(benches);

--- a/benches/from_rotation_vector_runtime.rs
+++ b/benches/from_rotation_vector_runtime.rs
@@ -1,60 +1,98 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use num_quaternion::{UQ32, UQ64};
+use rand::Rng;
+use rand::SeedableRng;
+use std::f32::consts::PI;
 use std::hint::black_box;
+
+/// Generates a vector of random 3D vectors where the norm of each is < PI.
+fn generate_random_vectors(count: usize) -> Vec<[f32; 3]> {
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(0x7F0829AE4D31C6B5);
+    (0..count)
+        .map(|_| {
+            // Use rejection sampling to ensure norm < PI
+            loop {
+                let v: [f32; 3] = [
+                    rng.random_range(-PI..PI),
+                    rng.random_range(-PI..PI),
+                    rng.random_range(-PI..PI),
+                ];
+                // Check using norm squared to avoid a sqrt call
+                if (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]) < PI * PI {
+                    return v;
+                }
+            }
+        })
+        .collect()
+}
 
 pub fn bench_from_rotation_vector(c: &mut Criterion) {
     {
-        let mut group = c.benchmark_group("num_quaternion");
+        // We'll process a batch of vectors in each iteration to measure throughput accurately.
+        const BATCH_SIZE: usize = 2_000;
+
+        // Pre-generate the random input data.
+        let inputs = generate_random_vectors(BATCH_SIZE);
+
+        // Create a buffer for the results to ensure the compiler can't optimize away the work.
+        let mut outputs = vec![UQ32::default(); BATCH_SIZE];
+
+        let mut group = c.benchmark_group("batch_conversion");
+
+        // Set the measurement to be based on the number of elements processed.
+        group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+
+        // Define the benchmark. `b.iter` runs the provided closure multiple times.
         group.bench_function("UQ32::from_rotation_vector", |b| {
-            b.iter(|| black_box(UQ32::from_rotation_vector(&[1.0, 2.0, 0.5])))
+            b.iter(|| {
+                // The code inside this closure is what's measured.
+                for i in 0..BATCH_SIZE {
+                    // Use `black_box` on the input to prevent the compiler from making assumptions.
+                    let input_vec = black_box(&inputs[i]);
+                    outputs[i] = UQ32::from_rotation_vector(input_vec);
+                }
+                // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                black_box(&mut outputs);
+            })
         });
-        group.bench_function("UQ64::from_rotation_vector", |b| {
-            b.iter(|| black_box(UQ64::from_rotation_vector(&[1.0, 2.0, 0.5])))
-        });
-    }
-    {
-        let mut group = c.benchmark_group("f32 polynomial");
         group.bench_function(
             "UQ32::from_rotation_vector_f32_polynomial",
             |b| {
                 b.iter(|| {
-                    black_box(UQ32::from_rotation_vector_f32_polynomial(
-                        &[1.0, 2.0, 0.5],
-                        5.25,
-                    ))
+                    // The code inside this closure is what's measured.
+                    for i in 0..BATCH_SIZE {
+                        // Use `black_box` on the input to prevent the compiler from making assumptions.
+                        let input_vec = black_box(&inputs[i]);
+                        let sqr_norm = input_vec[0] * input_vec[0]
+                            + input_vec[1] * input_vec[1]
+                            + input_vec[2] * input_vec[2];
+                        outputs[i] = UQ32::from_rotation_vector_f32_polynomial(
+                            input_vec, sqr_norm,
+                        );
+                    }
+                    // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                    black_box(&mut outputs);
                 })
             },
         );
-        group.bench_function(
-            "UQ64::from_rotation_vector_f32_polynomial",
-            |b| {
-                b.iter(|| {
-                    black_box(UQ64::from_rotation_vector_f32_polynomial(
-                        &[1.0, 2.0, 0.5],
-                        5.25,
-                    ))
-                })
-            },
-        );
-    }
-    {
-        let mut group = c.benchmark_group("generic implementation");
         group.bench_function("UQ32::from_rotation_vector_generic", |b| {
             b.iter(|| {
-                black_box(UQ32::from_rotation_vector_generic(
-                    &[1.0, 2.0, 0.5],
-                    5.25,
-                ))
+                // The code inside this closure is what's measured.
+                for i in 0..BATCH_SIZE {
+                    // Use `black_box` on the input to prevent the compiler from making assumptions.
+                    let input_vec = black_box(&inputs[i]);
+                    let sqr_norm = input_vec[0] * input_vec[0]
+                        + input_vec[1] * input_vec[1]
+                        + input_vec[2] * input_vec[2];
+                    outputs[i] =
+                        UQ32::from_rotation_vector_generic(input_vec, sqr_norm);
+                }
+                // Use `black_box` on the output to ensure the write to the vector is not optimized away.
+                black_box(&mut outputs);
             })
         });
-        group.bench_function("UQ64::from_rotation_vector_generic", |b| {
-            b.iter(|| {
-                black_box(UQ64::from_rotation_vector_generic(
-                    &[1.0, 2.0, 0.5],
-                    5.25,
-                ))
-            });
-        });
+
+        group.finish();
     }
 }
 

--- a/examples/chebyshev_approximation.rs
+++ b/examples/chebyshev_approximation.rs
@@ -1,0 +1,271 @@
+//! This executable computes polynomial approximations of special functions
+//! which are used in the implementation of the crate. The polynomial
+//! approximations are compared against the naive implementations and generally
+//! show higher accuracy and faster runtime.
+
+use std::{
+    f64::consts::PI,
+    ops::{Add, Mul},
+};
+
+/// A type representing a polynomial as a vector of its coefficients.
+/// The coefficients are ordered from the constant term upwards, e.g.,
+/// `vec![c0, c1, c2]` represents the polynomial `c0 + c1*x + c2*x^2`.
+/// Leading coefficients are always non-zero.
+#[derive(Clone, Debug, PartialEq)]
+struct Poly(Vec<f64>);
+
+/* Polynomial Utility Functions */
+
+impl Poly {
+    fn new(coeffs: Vec<f64>) -> Self {
+        let mut p = Poly(coeffs);
+        p.trim_zeros();
+        p
+    }
+
+    fn degree(&self) -> usize {
+        self.0.len().max(1) - 1
+    }
+
+    fn eval(&self, x: f64) -> f64 {
+        self.0.iter().rev().fold(0.0, |acc, &coeff| acc * x + coeff)
+    }
+
+    /// Trims trailing zero coefficients from a polynomial representation.
+    /// This is useful for cleaning up results from polynomial arithmetic.
+    fn trim_zeros(&mut self) {
+        while let Some(&0.0) = self.0.last() {
+            self.0.pop();
+        }
+    }
+
+    /// Composes a polynomial `P(y)` with a linear function `y = mx + c`.
+    /// The result is a new polynomial in `x`, `P(mx + c)`.
+    /// This implementation uses a Horner-like scheme for polynomial composition.
+    fn compose_linear(&self, m: f64, c: f64) -> Poly {
+        if self.0.len() <= 1 {
+            return self.clone();
+        }
+
+        let linear_poly = Poly::new(vec![c, m]); // Represents c + mx
+
+        // Start with the highest coefficient as a constant polynomial
+        let mut result =
+            Poly::new(vec![*self.0.last().expect("Polynomial is zero")]);
+
+        // Iterate downwards from the second-to-last coefficient
+        for &coeff in self.0.iter().rev().skip(1) {
+            result = &result * &linear_poly;
+            result.0[0] += coeff;
+        }
+        result
+    }
+}
+
+impl Add for &Poly {
+    type Output = Poly;
+
+    fn add(self, other: &Poly) -> Poly {
+        let mut result = self.0.clone();
+        let max_len = result.len().max(other.0.len());
+        result.resize(max_len, 0.0);
+        for (r, o) in result.iter_mut().zip(other.0.iter()) {
+            *r += o;
+        }
+        let mut result = Poly::new(result);
+        result.trim_zeros();
+        result
+    }
+}
+
+impl Mul<f64> for &Poly {
+    type Output = Poly;
+
+    fn mul(self, scalar: f64) -> Poly {
+        if scalar == 0.0 {
+            return Poly::new(vec![]);
+        }
+        let result = self.0.iter().map(|&c| c * scalar).collect();
+        Poly::new(result)
+    }
+}
+
+impl Mul for &Poly {
+    type Output = Poly;
+
+    fn mul(self, other: &Poly) -> Poly {
+        if self.0 == Vec::<f64>::new() || other.0 == Vec::<f64>::new() {
+            return Poly::new(vec![]);
+        }
+        let deg1 = self.degree();
+        let deg2 = other.degree();
+        let mut result = vec![0.0; deg1 + deg2 + 1];
+        for i in 0..=deg1 {
+            for j in 0..=deg2 {
+                result[i + j] += self.0[i] * other.0[j];
+            }
+        }
+        Poly::new(result)
+    }
+}
+
+/// Generates the `k`-th Chebyshev polynomial of the first kind, `T_k(x)`.
+fn chebyshev_poly(k: usize) -> Poly {
+    match k {
+        0 => Poly::new(vec![1.0]),
+        1 => Poly::new(vec![0.0, 1.0]),
+        _ => {
+            let mut tkm1 = Poly::new(vec![1.0]); // T_{k-1}
+            let mut tk = Poly::new(vec![0.0, 1.0]); // T_k
+
+            for _ in 1..k {
+                // T_{k+1} = 2x * T_k - T_{k-1}
+                let two_x = Poly::new(vec![0.0, 2.0]);
+                let tkp1 = &(&two_x * &tk) + &(&tkm1 * -1.0);
+
+                tkm1 = tk;
+                tk = tkp1;
+            }
+            tk
+        }
+    }
+}
+
+/// Computes the L2 Chebyshev approximation for a function given as a polynomial.
+///
+/// # Arguments
+/// * `f_coeffs` - The coefficients of the input polynomial `f(x)`.
+/// * `a`, `b` - The start and end points of the interval `[a, b]`.
+/// * `epsilon` - The desired upper bound maximum error on the interval `[a, b]`.
+///
+/// # Returns
+/// A `Result` containing the coefficients of the approximating polynomial,
+/// or an error string if the inputs are invalid.
+fn chebyshev_l2_approximation(
+    f_coeffs: &Poly,
+    a: f64,
+    b: f64,
+    epsilon: f64,
+) -> Result<Poly, String> {
+    if a >= b {
+        return Err("Invalid interval: a must be less than b.".to_string());
+    }
+    if epsilon <= 0.0 {
+        return Err("Epsilon must be positive.".to_string());
+    }
+
+    let degree = f_coeffs.degree();
+    if degree == 0 {
+        return Ok(f_coeffs.clone()); // Function is a constant
+    }
+
+    // 1. Compute Chebyshev Coefficients using Clenshaw-Curtis Quadrature
+    // The number of nodes N should be > 2*degree for accuracy.
+    let n_nodes = 2 * degree + 2;
+    let mut chebyshev_coeffs = vec![0.0; degree + 1];
+
+    for (k, coeff) in chebyshev_coeffs.iter_mut().enumerate() {
+        let mut sum = 0.0;
+        for j in 0..=n_nodes {
+            // Map standard Chebyshev nodes from [-1, 1] to [a, b]
+            let y_j = (j as f64 * PI / n_nodes as f64).cos();
+            let x_j = 0.5 * (a + b) + 0.5 * (b - a) * y_j;
+
+            let f_val = f_coeffs.eval(x_j);
+            let term =
+                f_val * (k as f64 * j as f64 * PI / n_nodes as f64).cos();
+
+            // First and last terms of the sum are halved
+            if j == 0 || j == n_nodes {
+                sum += 0.5 * term;
+            } else {
+                sum += term;
+            }
+        }
+        *coeff = 2.0 / n_nodes as f64 * sum;
+    }
+    // The c_0 coefficient has a different normalization in the error formula,
+    // but it's simpler to just handle it here.
+    chebyshev_coeffs[0] /= 2.0;
+
+    // 2. Find the minimal degree `n` that satisfies the error bound.
+    let mut tail_sum = 0.0;
+    let mut n = degree;
+    for k in (1..=degree).rev() {
+        let new_tail_sum = tail_sum + chebyshev_coeffs[k].abs();
+        if new_tail_sum > epsilon {
+            n = k;
+            break;
+        }
+        tail_sum = new_tail_sum;
+    }
+
+    // 3. Construct the approximating polynomial from the truncated series.
+    // P_n(x) = sum_{k=0 to n} c_k * T_k(y), where y is the mapped x.
+    let mut approx_poly = Poly::new(vec![chebyshev_coeffs[0]]);
+    let m = 2.0 / (b - a);
+    let c = -(a + b) / (b - a);
+
+    for k in 1..=n {
+        let tk_poly = chebyshev_poly(k);
+        let tk_composed = tk_poly.compose_linear(m, c);
+        approx_poly = &approx_poly + &(&tk_composed * chebyshev_coeffs[k]);
+    }
+
+    Ok(approx_poly)
+}
+
+fn factorial(n: usize) -> f64 {
+    (1..=n).fold(1.0, |acc, x| acc * x as f64)
+}
+
+fn main() {
+    // Example: Approximate f(x) = sinc(sqrt(x)) on [0, (pi/2)^2]
+    // We use the Taylor series of sinc(x) up to degree 50 as our input polynomial.
+    // sinc(x) = sin(x)/x = 1 - x^2/6 + x^4/120 - x^6/5040 + x^8/362880 + ...
+    // sinc(sqrt(x)) = 1 - x/6 + x^2/120 - x^3/5040 + x^4/362880 + ...
+    let sinc_sqrt_poly = Poly::new(
+        (0..=50)
+            .map(|n| if n % 2 == 0 { 1.0 } else { -1.0 } / factorial(2 * n + 1))
+            .collect(),
+    );
+
+    let a = 0.0;
+    let b = (std::f64::consts::PI / 2.0).powi(2);
+    let epsilon = 5.0 * f32::EPSILON as f64;
+
+    println!(
+        "Approximating a polynomial of degree {}",
+        sinc_sqrt_poly.degree()
+    );
+
+    match chebyshev_l2_approximation(&sinc_sqrt_poly, a, b, epsilon) {
+        Ok(approx_coeffs) => {
+            println!("Approximation successful!");
+            println!("Original degree: {}", sinc_sqrt_poly.degree());
+            println!("Minimized degree: {}", approx_coeffs.degree());
+            println!("Resulting coefficients: {:?}", approx_coeffs);
+
+            // Verify the error at a few points
+            println!("\nError verification at sample points:");
+            let mut max_error = 0.0f64;
+            for i in ((a * 100.0) as i32)..=((b * 100.0) as i32) {
+                let x = i as f64 / 100.0;
+                let original_val = sinc_sqrt_poly.eval(x);
+                let approx_val = approx_coeffs.eval(x);
+                let error =
+                    (original_val - approx_val).abs() / f32::EPSILON as f64;
+                max_error = max_error.max(error);
+                println!(
+                    "x={:>6.2}  f(x)={:>12.7}  p(x)={:>12.7}  err={:>10.2}eps",
+                    x, original_val, approx_val, error
+                );
+            }
+            println!("Maximum error: {:.7} eps", max_error);
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+        }
+    }
+}

--- a/examples/chebyshev_approximation.rs
+++ b/examples/chebyshev_approximation.rs
@@ -285,7 +285,14 @@ fn run_chebyshev_approximation(
             println!("Approximation successful!");
             println!("Original degree: {}", power_series.degree());
             println!("Minimized degree: {}", approx_coeffs.degree());
-            println!("Resulting coefficients: {:?}", approx_coeffs);
+            println!(
+                "Resulting coefficients: {:?}",
+                approx_coeffs
+                    .0
+                    .iter()
+                    .map(|c| *c as f32)
+                    .collect::<Vec<_>>()
+            );
 
             // Verify the error at a few points
             let mut max_error_f64 = 0.0f64;

--- a/src/unit_quaternion.rs
+++ b/src/unit_quaternion.rs
@@ -247,8 +247,9 @@ where
     /// ```
     pub fn from_rotation_vector(v: &[T; 3]) -> Self {
         let sqr_norm = v[0] * v[0] + v[1] * v[1] + v[2] * v[2];
-        let pi = core::f64::consts::PI;
-        let pi_square = T::from(pi * pi).unwrap();
+        const PI_SQUARED_F64: f64 =
+            core::f64::consts::PI * core::f64::consts::PI;
+        let pi_square = T::from(PI_SQUARED_F64).unwrap();
         if T::epsilon() >= T::from(f32::EPSILON).unwrap()
             && sqr_norm <= pi_square
         {

--- a/src/unit_quaternion.rs
+++ b/src/unit_quaternion.rs
@@ -258,7 +258,8 @@ where
         }
     }
 
-    /// Computes the unit quaternion corresponding to a rotation vector using a
+    /// This function is public for internal benchmarking purposes only. It
+    /// computes the unit quaternion corresponding to a rotation vector using a
     /// Chebyshev polynomial optimized for f32 precision and angles less than π.
     ///
     /// This method is used internally for rotation vectors whose norm is less
@@ -287,7 +288,10 @@ where
     /// Panics if the conversion between `T` and `f32` fails. This never happens
     /// for built-in floating-point types (`f32`, `f64`), but may occur for
     /// custom types.
-    fn from_rotation_vector_f32_polynomial(v: &[T; 3], sqr_norm: T) -> Self {
+    pub fn from_rotation_vector_f32_polynomial(
+        v: &[T; 3],
+        sqr_norm: T,
+    ) -> Self {
         let x = sqr_norm.to_f32().unwrap();
         // The magic numbers below are calculated in
         // `examples/chebyshev_approximation.rs`.
@@ -317,12 +321,13 @@ where
         ))
     }
 
-    /// A generic implementation of `from_rotation_vector()`.
+    /// This function is public for internal benchmarking purposes only. It is
+    /// a generic implementation of `from_rotation_vector()`.
     ///
     /// This method is used to implement `from_rotation_vector()` for floating
     /// point types `T` whose epsilon is less than `f32::EPSILON` or when the
     /// norm of the rotation vector is greater than π.
-    fn from_rotation_vector_generic(v: &[T; 3], sqr_norm: T) -> Self {
+    pub fn from_rotation_vector_generic(v: &[T; 3], sqr_norm: T) -> Self {
         let two = T::one() + T::one();
         match sqr_norm.classify() {
             FpCategory::Normal => {

--- a/src/unit_quaternion.rs
+++ b/src/unit_quaternion.rs
@@ -288,6 +288,7 @@ where
     /// Panics if the conversion between `T` and `f32` fails. This never happens
     /// for built-in floating-point types (`f32`, `f64`), but may occur for
     /// custom types.
+    #[inline]
     pub fn from_rotation_vector_f32_polynomial(
         v: &[T; 3],
         sqr_norm: T,
@@ -327,6 +328,7 @@ where
     /// This method is used to implement `from_rotation_vector()` for floating
     /// point types `T` whose epsilon is less than `f32::EPSILON` or when the
     /// norm of the rotation vector is greater than π.
+    #[inline]
     pub fn from_rotation_vector_generic(v: &[T; 3], sqr_norm: T) -> Self {
         let two = T::one() + T::one();
         match sqr_norm.classify() {


### PR DESCRIPTION
# Summary

## Description of Changes

Introduce polynomial approximations for `sinc(sqrt(x))` and `cos(sqrt(x))`. These are used to optimize `from_rotation_vector()` for `f32` precision. Added benchmarks to evaluate performance against the previous implementation and other packages. 

## Related Issue

Fixes #121

## Checklist

- [ ] I have reviewed my changes
- [x] I updated the release notes
- [x] I documented all new code
- [ ] I tested all new code

(If an item is not applicable, please check it anyway.)
