### PR TITLE
Updated to Rust edition 2024.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/ralphtandetzky/num-quaternion"
 version = "1.0.8"
 readme = "README.md"
 exclude = ["/.github/*"]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.0"
 
 [package.metadata.docs.rs]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 
+- Updated to Rust edition 2024.
 - Optimized `UnitQuaternion::adjust_norm` for norms close to 1, avoiding an
   expensive `sqrt` and division in the common case.
 - Updated `nalgebra` to version 0.34.2.

--- a/benches/from_rotation_vector_runtime.rs
+++ b/benches/from_rotation_vector_runtime.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use num_quaternion::UQ32;
 use rand::Rng;
 use rand::SeedableRng;

--- a/benches/norm_runtime.rs
+++ b/benches/norm_runtime.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use num_quaternion::{Q32, Q64};
 use std::hint::black_box;
 

--- a/benches/to_rotation_vector_runtime.rs
+++ b/benches/to_rotation_vector_runtime.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use num_quaternion::UQ32;
 use rand::Rng;
 use rand::SeedableRng;

--- a/examples/benchmark_norm_accuracy.rs
+++ b/examples/benchmark_norm_accuracy.rs
@@ -121,11 +121,23 @@ fn main() {
             io::stdout().flush().unwrap();
         }
     }
-    println!("\n\nThe columns of the table determine the scale of the input quaternion.");
-    println!("The rows of the table determine the implementation of the quaternion norm.");
-    println!("The values in the table are the relative RMS error of the quaternion norm.");
-    println!("\nThe column `1.0` is for quaternions with all components uniformly sampled from the range [-1.0, 1.0].");
-    println!("The column `sqrt(MIN_POS)` is for quaternions with all components in the range [sqrt(MIN_POS), sqrt(MIN_POS)],");
-    println!("where `MIN_POS` is the minimal positive normal 32-bit IEEE-754 floating point value. Similarly for `MIN_POS`");
+    println!(
+        "\n\nThe columns of the table determine the scale of the input quaternion."
+    );
+    println!(
+        "The rows of the table determine the implementation of the quaternion norm."
+    );
+    println!(
+        "The values in the table are the relative RMS error of the quaternion norm."
+    );
+    println!(
+        "\nThe column `1.0` is for quaternions with all components uniformly sampled from the range [-1.0, 1.0]."
+    );
+    println!(
+        "The column `sqrt(MIN_POS)` is for quaternions with all components in the range [sqrt(MIN_POS), sqrt(MIN_POS)],"
+    );
+    println!(
+        "where `MIN_POS` is the minimal positive normal 32-bit IEEE-754 floating point value. Similarly for `MIN_POS`"
+    );
     println!("and `MAX / 2`, where `MAX` is the maximal finite `f32` value.");
 }

--- a/examples/benchmark_rotation_vector_accuracy.rs
+++ b/examples/benchmark_rotation_vector_accuracy.rs
@@ -44,8 +44,12 @@ fn measure_round_trip_error(
 }
 
 fn main() {
-    println!("Benchmarking the absolute accuracy of rotation vector round-trip conversions");
-    println!("(to_rotation_vector followed by from_rotation_vector) for different rotation angles.\n");
+    println!(
+        "Benchmarking the absolute accuracy of rotation vector round-trip conversions"
+    );
+    println!(
+        "(to_rotation_vector followed by from_rotation_vector) for different rotation angles.\n"
+    );
 
     let col_width = 15;
 

--- a/src/arithmetics.rs
+++ b/src/arithmetics.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{Quaternion, UnitQuaternion, Q32, Q64, UQ32, UQ64},
+    crate::{Q32, Q64, Quaternion, UQ32, UQ64, UnitQuaternion},
     core::ops::{
         Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign,
     },
@@ -7,7 +7,7 @@ use {
 };
 
 #[cfg(feature = "unstable")]
-use crate::{PureQuaternion, PQ32, PQ64};
+use crate::{PQ32, PQ64, PureQuaternion};
 
 impl<T> Add<Quaternion<T>> for Quaternion<T>
 where
@@ -1075,9 +1075,9 @@ impl_bin_op_assign!(impl DivAssign::div_assign as Div::div for PureQuaternion);
 #[cfg(test)]
 mod tests {
 
-    use crate::{Quaternion, Q32, Q64, UQ32, UQ64};
     #[cfg(feature = "unstable")]
     use crate::{PQ32, PQ64};
+    use crate::{Q32, Q64, Quaternion, UQ32, UQ64};
 
     #[test]
     fn test_add_quaternion() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,9 +175,9 @@ mod quaternion;
 mod unit_quaternion;
 
 pub use {
-    quaternion::{Quaternion, Q32, Q64},
-    unit_quaternion::{EulerAngles, ReadMat3x3, UnitQuaternion, UQ32, UQ64},
+    quaternion::{Q32, Q64, Quaternion},
+    unit_quaternion::{EulerAngles, ReadMat3x3, UQ32, UQ64, UnitQuaternion},
 };
 
 #[cfg(feature = "unstable")]
-pub use pure_quaternion::{PureQuaternion, PQ32, PQ64};
+pub use pure_quaternion::{PQ32, PQ64, PureQuaternion};

--- a/src/quaternion.rs
+++ b/src/quaternion.rs
@@ -794,11 +794,7 @@ where
                 let map = |a: T| {
                     // Map zero to zero with same sign and everything else to
                     // infinity with same sign as the input.
-                    if a.is_zero() {
-                        a
-                    } else {
-                        inf.copysign(a)
-                    }
+                    if a.is_zero() { a } else { inf.copysign(a) }
                 };
                 let sqr_angle =
                     self.x * self.x + self.y * self.y + self.z * self.z;
@@ -1378,11 +1374,7 @@ where
                     || self.z.is_infinite()
                 {
                     let f = |a: T| {
-                        if a.is_infinite() {
-                            a
-                        } else {
-                            zero.copysign(a)
-                        }
+                        if a.is_infinite() { a } else { zero.copysign(a) }
                     };
                     Self::new(inf, f(self.x), f(self.y), f(self.z))
                 } else if self.w == -inf {
@@ -1445,7 +1437,7 @@ where
 mod tests {
 
     use {
-        crate::{Quaternion, Q32, Q64, UQ32, UQ64},
+        crate::{Q32, Q64, Quaternion, UQ32, UQ64},
         num_traits::{ConstOne, ConstZero, Inv, One, Zero},
     };
 
@@ -2193,18 +2185,26 @@ mod tests {
     fn test_expf_neg_infinite_real_component_with_t_between_0_and_1() {
         // Test the expf power function for a negative infinite real base with
         // an exponent between 0 and 1
-        assert!(!Q32::new(f32::NEG_INFINITY, 0.0, 0.0, 0.0)
-            .expf(0.5)
-            .is_finite());
-        assert!(!Q32::new(f32::NEG_INFINITY, 0.0, 0.0, 0.0)
-            .expf(0.5)
-            .has_nan());
-        assert!(!Q32::new(f32::NEG_INFINITY, 1.0, 2.0, 3.0)
-            .expf(0.75)
-            .is_finite());
-        assert!(!Q32::new(f32::NEG_INFINITY, 1.0, 2.0, 3.0)
-            .expf(0.75)
-            .has_nan());
+        assert!(
+            !Q32::new(f32::NEG_INFINITY, 0.0, 0.0, 0.0)
+                .expf(0.5)
+                .is_finite()
+        );
+        assert!(
+            !Q32::new(f32::NEG_INFINITY, 0.0, 0.0, 0.0)
+                .expf(0.5)
+                .has_nan()
+        );
+        assert!(
+            !Q32::new(f32::NEG_INFINITY, 1.0, 2.0, 3.0)
+                .expf(0.75)
+                .is_finite()
+        );
+        assert!(
+            !Q32::new(f32::NEG_INFINITY, 1.0, 2.0, 3.0)
+                .expf(0.75)
+                .has_nan()
+        );
     }
 
     #[cfg(any(feature = "std", feature = "libm"))]

--- a/src/unit_quaternion.rs
+++ b/src/unit_quaternion.rs
@@ -1591,7 +1591,7 @@ where
 #[cfg(test)]
 mod tests {
     use {
-        crate::{Quaternion, UnitQuaternion, Q32, UQ32, UQ64},
+        crate::{Q32, Quaternion, UQ32, UQ64, UnitQuaternion},
         core::borrow::Borrow,
         num_traits::{ConstOne, One},
     };
@@ -1787,12 +1787,16 @@ mod tests {
     fn test_from_rotation_vector_infinite() {
         // Test `from_rotation_vector` for a vector with infinite components.
         let inf = f32::INFINITY;
-        assert!(UQ32::from_rotation_vector(&[inf, 0.0, 0.0])
-            .into_inner()
-            .is_all_nan());
-        assert!(UQ32::from_rotation_vector(&[inf, inf, inf])
-            .into_inner()
-            .is_all_nan());
+        assert!(
+            UQ32::from_rotation_vector(&[inf, 0.0, 0.0])
+                .into_inner()
+                .is_all_nan()
+        );
+        assert!(
+            UQ32::from_rotation_vector(&[inf, inf, inf])
+                .into_inner()
+                .is_all_nan()
+        );
     }
 
     #[cfg(any(feature = "std", feature = "libm"))]
@@ -1800,12 +1804,16 @@ mod tests {
     fn test_from_rotation_vector_nan_input() {
         // Test `from_rotation_vector` for a vector with infinite components.
         let nan = f64::NAN;
-        assert!(UQ64::from_rotation_vector(&[nan, 0.0, 0.0])
-            .into_inner()
-            .is_all_nan());
-        assert!(UQ64::from_rotation_vector(&[nan, nan, nan])
-            .into_inner()
-            .is_all_nan());
+        assert!(
+            UQ64::from_rotation_vector(&[nan, 0.0, 0.0])
+                .into_inner()
+                .is_all_nan()
+        );
+        assert!(
+            UQ64::from_rotation_vector(&[nan, nan, nan])
+                .into_inner()
+                .is_all_nan()
+        );
     }
 
     #[cfg(any(feature = "std", feature = "libm"))]
@@ -2909,8 +2917,8 @@ mod tests {
     fn test_unit_quaternion_sample_half_planes() {
         // Test that the sample distribution of unit quaternions is uniform
         use rand::{
-            distr::{Distribution, StandardUniform},
             RngExt,
+            distr::{Distribution, StandardUniform},
         };
         let num_iters = 1_000_000;
         let mut rng = make_seeded_rng();


### PR DESCRIPTION
# Summary

## Description of Changes

Since there are dependencies which are already using the 2024 edition, we can switch without affecting the minimum supported Rust version. 

## Related Issue

None.

## Checklist

- [x] I have reviewed my changes
- [x] I updated the release notes
- [x] I documented all new code
- [x] I tested all new code

(If an item is not applicable, please check it anyway.)
