### PR TITLE
Update serde_json to 1.0.150 and release notes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ version = "0.6.0"
 default-features = false
 
 [dev-dependencies.serde_json]
-version = "1.0.145"
+version = "1.0.150"
 
 [features]
 default = ["std"]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@
 - Updated to Rust edition 2024.
 - Optimized `UnitQuaternion::adjust_norm` for norms close to 1, avoiding an
   expensive `sqrt` and division in the common case.
-- Updated `nalgebra` to version 0.34.2.
+- Updated `nalgebra` to version 0.35.0 and `serde_json` to 1.0.150.
 - Updated C++ benchmark dependencies to their latest versions (`boost.qvm`,
   `eigen`, `google_benchmark`, `rules_cc`, `bazel_clang_tidy`).
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,8 @@
 - Updated to Rust edition 2024.
 - Optimized `UnitQuaternion::adjust_norm` for norms close to 1, avoiding an
   expensive `sqrt` and division in the common case.
-- Updated `nalgebra` to version 0.35.0 and `serde_json` to 1.0.150.
+- Updated `nalgebra` to version 0.35.0.
+- Updated `serde_json` to 1.0.150.
 - Updated C++ benchmark dependencies to their latest versions (`boost.qvm`,
   `eigen`, `google_benchmark`, `rules_cc`, `bazel_clang_tidy`).
 


### PR DESCRIPTION
# Summary

## Description of Changes

Updated the `serde_json` dependency to version 1.0.150 and revised the release notes to reflect this change.

## Related Issue

None

## Checklist

- [x] I have reviewed my changes
- [x] I updated the release notes
- [x] I documented all new code
- [x] I tested all new code

(If an item is not applicable, please check it anyway.)

