### PR TITLE
Update Bazel configuration for LLVM toolchain and clang-tidy integration

### DIFF
--- a/benches/c++/.bazelrc
+++ b/benches/c++/.bazelrc
@@ -1,7 +1,11 @@
 build --cxxopt='-std=c++20'
 build --cxxopt='-O3'
 build --cxxopt='-fdiagnostics-color=always'
+# The hermetic LLVM toolchain passes -stdlib=libc++ which is unused during
+# compilation (it only affects linking), triggering a spurious warning.
+build --cxxopt='-Wno-unused-command-line-argument'
 
 # Required for bazel_clang_tidy to operate as expected
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --output_groups=report
+build:clang-tidy --@bazel_clang_tidy//:clang_tidy_executable=@llvm_toolchain_llvm//:clang-tidy

--- a/benches/c++/MODULE.bazel
+++ b/benches/c++/MODULE.bazel
@@ -8,3 +8,13 @@ git_override(
     commit = "9e54bbb15d1939a9d030c52f3032886a0b278f98",
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )
+
+bazel_dep(name = "toolchains_llvm", version = "1.8.0")
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "19.1.7",
+)
+use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
+register_toolchains("@llvm_toolchain//:all")


### PR DESCRIPTION
Enhance the Bazel configuration to integrate the LLVM toolchain and improve clang-tidy functionality. Adjustments include suppressing unused command-line argument warnings and registering the LLVM toolchain for better compatibility.